### PR TITLE
docs: fix deno argument order

### DIFF
--- a/charts/feedbacksystem/Chart.yaml
+++ b/charts/feedbacksystem/Chart.yaml
@@ -6,7 +6,7 @@ sources:
   - https://github.com/thm-mni-ii/feedbacksystem
 home: https://github.com/thm-mni-ii/feedbacksystem
 type: application
-version: 0.5.0
+version: 0.5.1
 # renovate: image=thmmniii/fbs-core
 appVersion: v1.4.2
 dependencies:

--- a/charts/feedbacksystem/README.md
+++ b/charts/feedbacksystem/README.md
@@ -25,7 +25,7 @@ Official Helm Chart for Installing the [Feedbacksystem](https://github.com/thm-m
 There is a [Deno](https://deno.land) script to generate the configuration file for this helm chart. It generates random values for all secrets to be changed and asks for configuration values.
 
 - **Source:** [generate-values.ts](https://github.com/thm-mni-ii/helm-charts/blob/main/charts/feedbacksystem/generate-values.ts)
-- **Usage:** `deno run --reload=https://raw.githubusercontent.com https://raw.githubusercontent.com/thm-mni-ii/helm-charts/main/charts/feedbacksystem/generate-values.ts --allow-write=vals.yaml vals.yaml`
+- **Usage:** `deno run --reload=https://raw.githubusercontent.com --allow-write=vals.yaml https://raw.githubusercontent.com/thm-mni-ii/helm-charts/main/charts/feedbacksystem/generate-values.ts vals.yaml`
 
 ### Parameters
 


### PR DESCRIPTION
Deno requires the `--allow-write` argument to appear before the script name and displays the following warning otherwise:
```
Permission flags have likely been incorrectly set after the script argument.
To grant permissions, set them before the script argument. For example:
    deno run --allow-read=. main.js
```
